### PR TITLE
chore: update angular to 2.0.0-alpha.52

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Angular2 Seed
 
-- Angular `2.0.0-alpha.48`
+- Angular `2.0.0-alpha.52`
 - BrowserSync
 - ES6 Shim
 - Gulp `4.0.0-alpha.2`

--- a/karma.entry.js
+++ b/karma.entry.js
@@ -11,7 +11,6 @@ System.config({
   packages: {
     'base/target': {
       defaultExtension: 'js',
-      format: 'register',
       map: Object.keys(window.__karma__.files)
         .filter(filterSourceFiles)
         .reduce(function(mapping, path){

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "test": "./node_modules/.bin/gulp test"
   },
   "dependencies": {
-    "angular2": "2.0.0-alpha.48",
+    "angular2": "2.0.0-alpha.52",
     "es6-shim": "~0.33.13",
+    "rxjs": "5.0.0-alpha.14",
     "systemjs": "~0.19.6"
   },
   "devDependencies": {
@@ -30,15 +31,17 @@
     "gulp": "gulpjs/gulp.git#4.0",
     "gulp-changed": "~1.3.0",
     "gulp-postcss": "~6.0.1",
-    "gulp-sass": "~2.1.0",
+    "gulp-sass": "~2.1.1",
     "gulp-sourcemaps": "~1.6.0",
-    "gulp-tslint": "~4.1.1",
+    "gulp-tslint": "~4.1.2",
     "gulp-typescript": "~2.10.0",
     "jasmine-core": "~2.4.1",
     "karma": "~0.13.15",
     "karma-chrome-launcher": "~0.2.2",
     "karma-jasmine": "~0.3.6",
+    "reflect-metadata": "~0.1.2",
     "tslint": "~3.1.1",
-    "typescript": "~1.7.3"
+    "typescript": "~1.7.3",
+    "zone.js": "~0.5.9"
   }
 }

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -16,7 +16,7 @@ import { Projects } from '../projects/projects';
 
   template: `
     <header>
-      <a [router-link]="['/Home']">Home</a> | <a [router-link]="['/Projects']">Projects</a>
+      <a [routerLink]="['/Home']">Home</a> | <a [routerLink]="['/Projects']">Projects</a>
     </header>
 
     <main>

--- a/src/components/projects/projects.html
+++ b/src/components/projects/projects.html
@@ -1,5 +1,5 @@
 <h2>Projects</h2>
 
 <ul>
-  <li *ng-for="#project of projects.list">{{project.name}}</li>
+  <li *ngFor="#project of projects.list">{{project.name}}</li>
 </ul>

--- a/src/components/projects/projects.ts
+++ b/src/components/projects/projects.ts
@@ -3,6 +3,7 @@ import { ProjectService } from '../../modules/project/project-service';
 
 
 @Component({
+  moduleId: module.id,
   selector: 'projects',
   viewProviders: [
     ProjectService
@@ -13,8 +14,8 @@ import { ProjectService } from '../../modules/project/project-service';
   directives: [
     NgFor
   ],
-  styleUrls: ['components/projects/projects.css'],
-  templateUrl: 'components/projects/projects.html'
+  styleUrls: ['./projects.css'],
+  templateUrl: './projects.html'
 })
 
 export class Projects {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "experimentalAsyncFunctions": true,
     "experimentalDecorators": true,
     "listFiles": true,
-    "module": "system",
+    "module": "commonjs",
     "moduleResolution": "node",
     "noEmitHelpers": false,
     "noImplicitAny": false,


### PR DESCRIPTION
Angular2 now supports relative asset paths for components styles and templates https://github.com/angular/angular/pull/5634
____
**BREAKING CHANGE**: Angular is now fully camel case.

Before:
```
    <p *ng-if="cond">
    <my-cmp [my-prop]="exp">
    <my-cmp (my-event)="action()">
    <my-cmp [(my-prop)]="prop">
    <input #my-input>
    <template ng-for #my-item [ng-for-of]=items #my-index="index">
```
After:
```
    <p *ngIf="cond">
    <my-cmp [myProp]="exp">
    <my-cmp (myEvent)="action()">
    <my-cmp [(myProp)]="prop">
    <input #myInput>`,
    <template ngFor="#my-item" [ngForOf]=items #myIndex="index">
```

https://github.com/angular/angular/blob/master/CHANGELOG.md#200-alpha52-2015-12-10